### PR TITLE
boilerplate implementation of comm proxy backed by acecomm

### DIFF
--- a/Modules/Comms/Comms.lua
+++ b/Modules/Comms/Comms.lua
@@ -1,3 +1,34 @@
 -- local  _, CLM = ...
 
 -- local Comms = CLM.core:NewModule("Comms", {}, "AceComm-3.0", "LibSerialize", "LibDeflate")
+
+Comms = LibStub:NewLibrary("CLM/Modules/Comms", 1)
+if not Comms then return end
+
+local aceComm = LibStub('AceComm-3.0')
+
+function Comms:getSend(prefix)
+    return function(text, distribution, target, prio, callbackFn, callbackArg)
+        -- CLM internal proxy implementation here
+        -- Note that there is no prefix here.
+        aceComm:SendAddonMessage(prefix, text, distribution, target, prio, callbackFn, callbackArg)
+    end
+end
+
+function Comms:getReceiveHandlerRegister(prefix)
+    return function(callback)
+        aceComm:RegisterComm(prefix, function(_, message, distribution, sender)
+            -- Authorize sender
+
+            -- Do something else
+
+
+            -- Send data to module
+
+            callback(message, distribution, sender)
+
+            -- Do something else after sending it to module
+
+        end)
+    end
+end


### PR DESCRIPTION
Just some sample code:

- [ ] Uses LibStub to register modules, so the main Addon can load them via LibStub
- [ ] Provides a proxy needed for the `Ledger` module