### PR TITLE
Only checkout source files

### DIFF
--- a/gitman.yml
+++ b/gitman.yml
@@ -5,7 +5,10 @@ sources:
     #rev:  v0.0.22
     rev:  master
     type: git
-
+    sparse_paths:
+      - /source
+      - *.toc
+      - *.xml
 location: Libs
 sources:
   - repo: https://github.com/lantisnt/LibLogger.git


### PR DESCRIPTION
This is untested, try it before merging.
This is just to illustrate how you can take what you need from library and not get files that you don't need when doing bad stuff like committing the source code to your own git repo.