### PR TITLE
fix synx state icon, add tooltip details

### DIFF
--- a/MinimapIcon.lua
+++ b/MinimapIcon.lua
@@ -49,6 +49,12 @@ do
         else -- Unknown state
             tooltip:AddLine("Unknown sync state", 0.4, 0.6, 1)
         end
+
+        local lag = CLM.MODULES.LedgerManager:Lag()
+        local count = CLM.MODULES.LedgerManager:Length()
+        local hash = CLM.MODULES.LedgerManager:Hash()
+        tooltip:AddLine(string.format("We have %d events, %d lag and our state is %s", count, lag, hash))
+
         tooltip:AddLine(" ")
         tooltip:AddLine("|cffcfcfcfLeft Click:|r Toggle Standings window")
         tooltip:AddLine("|cffcfcfcfShift + Left Click:|r Open configuration window")

--- a/Modules/LedgerManager/LedgerManager.lua
+++ b/Modules/LedgerManager/LedgerManager.lua
@@ -36,7 +36,7 @@ function LedgerManager:Initialize()
         end), -- sendLargeMessage
         0, 50, LOG
     )
-    self.ledger.addSyncStateChangedListener(function(status)
+    self.ledger.addSyncStateChangedListener(function(_, status)
         self:UpdateSyncState(status) -- there is still something fishy about the Icon (securehook) and I don't know what
     end)
     self.entryExtensions = {}
@@ -112,6 +112,17 @@ end
 
 function LedgerManager:IsSyncOngoing()
     return self.syncOngoing
+end
+
+function LedgerManager:Lag()
+    return self.ledger.getStateManager():lag()
+end
+
+function LedgerManager:Hash()
+    return self.ledger.getStateManager():stateHash()
+end
+function LedgerManager:Length()
+    return self.ledger.getSortedList():length()
 end
 
 function LedgerManager:RequestPeerStatusFromRaid()


### PR DESCRIPTION
This fixes the sync state icon as well as adding some more text to the tooltip related to sync status.

![image](https://user-images.githubusercontent.com/547021/118332751-e323b280-b50a-11eb-91b5-584818c426f2.png)
