### PR TITLE
Save amount of spent point to wowdkpbot

### DIFF
--- a/ClassicLootManager_Integrations/Integrations.lua
+++ b/ClassicLootManager_Integrations/Integrations.lua
@@ -69,7 +69,8 @@ local function StoreWoWDKPBotData(self)
             db.rosters[name][GUID] = {
                 dkp = value, -- set standings
                 loot = {},
-                history = {}
+                history = {},
+                spent = roster:GP(GUID)
             }
             local data = db.rosters[name][GUID]
             -- set loot


### PR DESCRIPTION
Current wowdkpbot integration doesn't save amount of spent points. This PR aimed on implementation of this feature. 

Having amount of spent points allow EPGP based guilds to have priority info available in Discord, etc.